### PR TITLE
The addition of +"T00:00:00" in lines 87 and 117 are in an effort to pre...

### DIFF
--- a/bday-picker.js
+++ b/bday-picker.js
@@ -85,7 +85,7 @@
 
       var hiddenDate;
       if (settings["defaultDate"]) {
-        var defDate = new Date(settings["defaultDate"]),
+        var defDate = new Date(settings["defaultDate"] + "T00:00:00"),
         defYear = defDate.getFullYear(),
         defMonth = defDate.getMonth() + 1,
         defDay = defDate.getDate();
@@ -114,7 +114,7 @@
 
       // Set the default date if given
       if (settings["defaultDate"]) {
-        var date = new Date(settings["defaultDate"]);
+        var date = new Date(settings["defaultDate"] + "T00:00:00");
         $year.val(date.getFullYear());
         $month.val(date.getMonth() + 1);
         $day.val(date.getDate());


### PR DESCRIPTION
...vent the plugin from specifying date in the Date in the day field as being 1 day off from whatever the provided default date is. Example, when I provided a default date of 1999-11-01 the select menu would indicate instead, Oct 31 1999. From what I can tell, this is an issue with regard to timezone. By making these changes to the plugin I was able to fix the '1 day off' issue.
